### PR TITLE
fix(api): return a JSON body from PUT /state/device/:binding

### DIFF
--- a/boards/Controller.ts
+++ b/boards/Controller.ts
@@ -3044,7 +3044,7 @@ export class I2cDevice extends ConfigItem {
             if (typeof bus === 'undefined') return Promise.reject(new Error(`setDeviceState: i2c Bus id ${bind.busId} is not initialized. - ${bind.binding}`));
             let dev = bus.devices.find(elem => elem.device.id === this.id);
             if (typeof dev === 'undefined') return Promise.reject(new Error(`setDeviceState: i2c Device id ${bind.busId}:${this.name} is not initialized. - ${bind.binding}`));
-            return await dev.setDeviceState(bind, data);
+            return { status: dev.deviceStatus, state: await dev.setDeviceState(bind, data) };
         }
         catch (err) { return Promise.reject(new Error(`setDeviceState: Error setting device state ${err.message}`)) }
     }

--- a/web/services/State.ts
+++ b/web/services/State.ts
@@ -84,7 +84,7 @@ export class StateRoute {
             try {
                 //console.log(`setDeviceState: ${req.params.binding} - ${JSON.stringify(req.body)}`);
                 let ret = await cont.setDeviceState(req.params.binding, req.body);
-                return res.status(200).send(ret);
+                return res.status(200).send(typeof ret === 'number' ? ret.toString() : ret);
             }
             catch (err) { next(err); }
         });


### PR DESCRIPTION
## Problem

Express treats a single numeric argument to `res.send()` as a **status code** — `res.send(status)` is the deprecated form of `res.sendStatus(status)`. So `res.status(200).send(ret)` in the `PUT /state/device/:binding` handler throws whenever `ret` is a bare number:

```
RangeError [ERR_HTTP_INVALID_STATUS_CODE]: Invalid status code: 3.814
```

Read-only i2c devices hit this on **every** PUT. `AtlasEZOprs.getDeviceState()` resolves to `this.values.pressure`, and since `AtlasEZOprs` doesn't override `setDeviceState()`, the base `i2cDeviceBase.setDeviceState()` returns that same bare number. `res.send()` then dies and the caller gets a 500 whose body is `Invalid status code: <the pressure reading>`.

Express's own deprecation warning has been pointing at the line the whole time:

```
express deprecated res.send(status): Use res.sendStatus(status) instead at dist/web/services/State.js:104:40
```

## Why it matters in practice

On an all-Nixie system this fires continuously. nodejs-poolController's Nixie filter (`setFilterStateAsync`) PUTs to its `deviceBinding` every poll, and because the response is never 200 it never latches `_lastState` — so it retries forever.

Measured on a live Pi with an EZO-PRS at `0x6a`, over 54 hours:

| | count |
|---|---|
| `Invalid status code: <reading>` | 51,047 |
| `Device not active` (same binding, before it was enabled) | 13,508 |
| **total PUTs to that binding** | **64,556** |

Every single PUT to the binding failed. njsPC logs nothing about it — `putDeviceService` has its error check commented out and `Filter.setFilterStateAsync` only checks `res.status.code === 200` — so the failure is completely silent on the consumer side.

## Changes

**1. `I2cDevice.setDeviceState()` now returns `{ status, state }`** — matching `I2cBus.getDeviceState()` (`Controller.ts:2500`) and the shape already used for spi (`:3163`), generic (`:3543`) and oneWire (`:4461`) devices. This is the actual shape fix.

**2. The PUT route now guards a numeric result**, the same way the GET route already does one line below. This is deliberate belt-and-braces: the gpio, spi, generic and oneWire `setDeviceState()` paths can also return bare values, and this prevents any of them coercing a reading into an HTTP status code.

## Compatibility

- **No in-repo consumer reads the PUT response body.** The only caller of `cont.setDeviceState()` outside the route is `connections/Bindings.ts`, which discards the result. Nothing under `pages/` references `state/device`.
- **njsPC is unaffected.** All 20 `putDeviceService` call sites inspect only `res.status.code` or `res.error`; none reads the body. The only observable change is the 500 becoming a 200 — which is the point.
- Filter pressure reaches njsPC over the REM socket **feed** (`eventName: "filter"`), not this endpoint, so the reading path is untouched.

## Verification

`npx tsc --noEmit` passes cleanly against `master` @ 10.0.0.

Reproduced before/after against this repo's Express (4.21.2):

```
PUT /before
  express deprecated res.send(status): Use res.sendStatus(status) instead
  -> error middleware saw: RangeError | Invalid status code: 3.814
  -> HTTP 500  body=Invalid status code: 3.814

PUT /after
  -> HTTP 200  body={"status":{"name":"EZO PRS","hasFault":false},"state":3.814}
```

## Note for a follow-up

`OneWireDevice.setDeviceState()` (`boards/Controller.ts:4980`) is a copy-paste of the i2c version and still carries the i2c wording in its error messages while looking up `oneWire.buses`. Left alone here to keep this change focused; the route-level guard covers its numeric-return crash in the meantime.